### PR TITLE
Fix release version check to ignore surrounding whitespace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
           version="$(
             sbt -batch -Dsbt.log.noformat=true --error 'print version' \
-              | awk 'NF { line = $0 } END { sub(/^\[info\][[:space:]]*/, "", line); print line }'
+              | awk 'NF { line = $0 } END { sub(/^\[info\][[:space:]]*/, "", line); gsub(/^[[:space:]]+|[[:space:]]+$/, "", line); print line }'
           )"
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "error: expected sbt version to match MAJOR.MINOR.PATCH, got: $version" >&2


### PR DESCRIPTION
## Summary
- trim leading/trailing whitespace from the parsed `sbt print version` output in the release workflow
- keep existing tag/version format checks unchanged

## Repro
- on a tagged clean checkout, `sbt -batch -Dsbt.log.noformat=true --error 'print version'` can emit the version with a leading tab (`\t0.0.2`)
- previous awk logic removed `[info]` but not arbitrary whitespace, so regex validation failed

## Verification
- reproduced the failing value locally (`09 30 2e 30 2e 32` bytes)
- verified in a clean throwaway clone on a tagged commit (`v0.0.99`) that the updated validation step parses `0.0.99` and passes
