### PR TITLE
Include z3.imports.json in release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,7 @@ jobs:
           shasum -a 256 \
             core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3.wasm \
             core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3.wasm.sha256 \
+            core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3.imports.json \
             core/jvm/target/scala-3.8.1/scalawasiz3*.jar \
             core/js/target/scala-3.8.1/scalawasiz3*.jar \
             > "${{ env.RELEASE_ASSET_DIR }}/SHA256SUMS"
@@ -114,6 +115,7 @@ jobs:
           files: |
             core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3.wasm
             core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3.wasm.sha256
+            core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3.imports.json
             core/jvm/target/scala-3.8.1/scalawasiz3*.jar
             core/js/target/scala-3.8.1/scalawasiz3*.jar
             target/release-assets/SHA256SUMS

--- a/tests/release-workflow-trigger.sh
+++ b/tests/release-workflow-trigger.sh
@@ -80,6 +80,11 @@ if ! grep -Eq "^[[:space:]]*core/shared/src/main/resources/dev/bosatsu/scalawasi
   exit 1
 fi
 
+if ! grep -Eq "^[[:space:]]*core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3\\.imports\\.json$" "$workflow_file"; then
+  echo "GitHub release upload must include z3.imports.json resource" >&2
+  exit 1
+fi
+
 if grep -Eq "OUT_WASM:[[:space:]]*\\$\\{\\{ env\\.RELEASE_ASSET_DIR \\}\\}/z3\\.wasm" "$workflow_file"; then
   echo "release workflow should build z3.wasm into the runtime resource path, not release-assets" >&2
   exit 1


### PR DESCRIPTION
Implemented issue #10 with a focused release-workflow change.

What changed:
- Updated `.github/workflows/release.yml` to add `core/shared/src/main/resources/dev/bosatsu/scalawasiz3/z3/z3.imports.json` to the `SHA256SUMS` generation inputs.
- Updated `.github/workflows/release.yml` to upload `z3.imports.json` in the GitHub release asset list.
- Updated `tests/release-workflow-trigger.sh` to assert that the release workflow includes `z3.imports.json` in uploaded assets, preventing regression.

Validation run:
- `bash tests/release-workflow-trigger.sh` passed.

Fixes #10

Source issue: https://github.com/johnynek/scalawasiz3/issues/10