### PR TITLE
Improve JVM Z3 throughput via Chicory runtime compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,34 @@ import dev.bosatsu.scalawasiz3.Z3Solver
 
 val solver = Z3Solver.default
 val result = solver.runSmt2("(check-sat)")
+
+// Optional: create an isolated reusable solver handle (useful per worker/thread)
+val threadLocalSolver = Z3Solver.create()
 ```
 
 `runSmt2` returns `Z3Result`, with:
 
 - `Z3Result.Success(stdout, stderr, exitCode = 0)`
 - `Z3Result.Failure(message, exitCode, stdout, stderr, cause)`
+
+## JVM benchmark
+
+Run the JVM benchmark harness:
+
+```bash
+sbt "project coreJVM" "runMain dev.bosatsu.scalawasiz3.JvmSolverBenchmarkMain --warmup 20 --iterations 200 --threads 4 --mode shared"
+```
+
+Modes:
+
+- `shared`: all benchmark threads share `Z3Solver.default`
+- `isolated`: each thread uses its own `Z3Solver.create()`
+
+Optional runtime-compiler disk cache (Chicory):
+
+```bash
+sbt -Dscalawasiz3.chicory.runtimeCompilerCacheDir=/tmp/chicory-cache "project coreJVM" "runMain dev.bosatsu.scalawasiz3.JvmSolverBenchmarkMain --warmup 20 --iterations 200 --threads 4 --mode shared"
+```
 
 ## CI and release
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 
-val chicoryVersion = "1.4.0"
+val chicoryVersion = "1.7.2"
 val munitVersion = "1.1.1"
 val munitScalacheckVersion = "1.1.0"
 val lz4JavaVersion = "1.8.0"
@@ -76,6 +76,8 @@ lazy val core =
     .jvmSettings(
       libraryDependencies ++= Seq(
         "com.dylibso.chicory" % "runtime" % chicoryVersion,
+        "com.dylibso.chicory" % "compiler" % chicoryVersion,
+        "com.dylibso.chicory" % "dircache-experimental" % chicoryVersion,
         "com.dylibso.chicory" % "wasm" % chicoryVersion,
         "com.dylibso.chicory" % "wasi" % chicoryVersion,
         "org.lz4" % "lz4-java" % lz4JavaVersion % Test,

--- a/core/js/src/main/scala/dev/bosatsu/scalawasiz3/Z3Platform.scala
+++ b/core/js/src/main/scala/dev/bosatsu/scalawasiz3/Z3Platform.scala
@@ -2,4 +2,6 @@ package dev.bosatsu.scalawasiz3
 
 object Z3Platform {
   lazy val default: Z3Solver = JsWasiZ3Solver
+
+  def create(): Z3Solver = JsWasiZ3Solver
 }

--- a/core/jvm/src/main/scala/dev/bosatsu/scalawasiz3/JvmSolverBenchmarkMain.scala
+++ b/core/jvm/src/main/scala/dev/bosatsu/scalawasiz3/JvmSolverBenchmarkMain.scala
@@ -1,0 +1,269 @@
+package dev.bosatsu.scalawasiz3
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Simple benchmark harness for measuring runSmt2 throughput on the JVM runtime.
+ *
+ * Usage:
+ *   sbt "project coreJVM" "runMain dev.bosatsu.scalawasiz3.JvmSolverBenchmarkMain --warmup 20 --iterations 200 --threads 1"
+ */
+object JvmSolverBenchmarkMain {
+  private sealed trait SolverMode
+  private object SolverMode {
+    case object Shared extends SolverMode
+    case object Isolated extends SolverMode
+
+    def parse(value: String): SolverMode =
+      value.trim.toLowerCase match {
+        case "shared" => Shared
+        case "isolated" => Isolated
+        case other =>
+          throw new IllegalArgumentException(
+            s"Unknown --mode value: $other (expected: shared|isolated)"
+          )
+      }
+  }
+
+  private final case class Config(
+      warmupIterations: Int = 20,
+      measuredIterations: Int = 200,
+      threads: Int = 1,
+      mode: SolverMode = SolverMode.Shared
+  )
+
+  private final case class SampleStats(
+      count: Int,
+      totalWallNanos: Long,
+      totalCallNanos: Long,
+      minNanos: Long,
+      maxNanos: Long,
+      p50Nanos: Long,
+      p95Nanos: Long
+  ) {
+    def callsPerSecond: Double = {
+      val seconds = totalWallNanos.toDouble / 1e9
+      if (seconds == 0d) Double.PositiveInfinity else count.toDouble / seconds
+    }
+
+    def averageCallMillis: Double = totalCallNanos.toDouble / count.toDouble / 1e6
+
+    def averageWallMillisPerCall: Double = totalWallNanos.toDouble / count.toDouble / 1e6
+  }
+
+  private val BenchmarkInput: String =
+    """(set-option :produce-models true)
+      |(declare-const x Int)
+      |(declare-const y Int)
+      |(assert (> x 10))
+      |(assert (< x 20))
+      |(assert (= y (+ x 4)))
+      |(check-sat)
+      |(get-model)
+      |""".stripMargin
+
+  def main(args: Array[String]): Unit = {
+    val cfg = parseConfig(args.toList)
+    validateConfig(cfg)
+
+    println(s"Warmup iterations: ${cfg.warmupIterations}")
+    println(s"Measured iterations: ${cfg.measuredIterations}")
+    println(s"Threads: ${cfg.threads}")
+    println(s"Mode: ${modeName(cfg.mode)}")
+
+    val solverFactory = cfg.mode match {
+      case SolverMode.Shared =>
+        val shared = Z3Solver.default
+        () => shared
+      case SolverMode.Isolated =>
+        () => Z3Solver.create()
+    }
+
+    warmup(solverFactory, cfg.warmupIterations)
+    val stats = runMeasured(solverFactory, cfg.measuredIterations, cfg.threads)
+
+    println(s"Total calls: ${stats.count}")
+    println(f"Total time: ${stats.totalWallNanos.toDouble / 1e9}%.3f s")
+    println(f"Throughput: ${stats.callsPerSecond}%.2f calls/s")
+    println(f"Avg call latency: ${stats.averageCallMillis}%.3f ms")
+    println(f"Avg wall time per call: ${stats.averageWallMillisPerCall}%.3f ms")
+    println(f"Min latency: ${toMillis(stats.minNanos)}%.3f ms")
+    println(f"P50 latency: ${toMillis(stats.p50Nanos)}%.3f ms")
+    println(f"P95 latency: ${toMillis(stats.p95Nanos)}%.3f ms")
+    println(f"Max latency: ${toMillis(stats.maxNanos)}%.3f ms")
+  }
+
+  private def warmup(solverFactory: () => Z3Solver, iterations: Int): Unit = {
+    val solver = solverFactory()
+    var i = 0
+    while (i < iterations) {
+      assertSat(solver.runSmt2(BenchmarkInput), s"warmup[$i]")
+      i += 1
+    }
+  }
+
+  private def runMeasured(
+      solverFactory: () => Z3Solver,
+      iterations: Int,
+      threads: Int
+  ): SampleStats = {
+    val callsPerThread = iterations / threads
+    val remainder = iterations % threads
+    val allSamples = Array.ofDim[Long](iterations)
+    val nextWrite = new AtomicInteger(0)
+
+    val startLatch = new CountDownLatch(1)
+    val doneLatch = new CountDownLatch(threads)
+    val errors = new AtomicInteger(0)
+    val runStart = System.nanoTime()
+
+    var t = 0
+    while (t < threads) {
+      val extra = if (t < remainder) 1 else 0
+      val thisThreadIterations = callsPerThread + extra
+      val thread = new Thread(
+        new Runnable {
+          override def run(): Unit = {
+            val solver = solverFactory()
+            try {
+              startLatch.await()
+              var i = 0
+              while (i < thisThreadIterations) {
+                val t0 = System.nanoTime()
+                val result = solver.runSmt2(BenchmarkInput)
+                val dt = System.nanoTime() - t0
+                assertSat(result, s"run[$i]")
+                val idx = nextWrite.getAndIncrement()
+                allSamples(idx) = dt
+                i += 1
+              }
+            } catch {
+              case _: Throwable =>
+                errors.incrementAndGet()
+            } finally {
+              doneLatch.countDown()
+            }
+          }
+        },
+        s"z3-bench-$t"
+      )
+      thread.start()
+      t += 1
+    }
+
+    startLatch.countDown()
+    doneLatch.await()
+    val runTotalNanos = System.nanoTime() - runStart
+
+    if (errors.get() > 0) {
+      throw new RuntimeException(s"Benchmark failed with ${errors.get()} thread errors")
+    }
+
+    val sorted = java.util.Arrays.copyOf(allSamples, allSamples.length)
+    java.util.Arrays.sort(sorted)
+    val min = sorted(0)
+    val max = sorted(sorted.length - 1)
+    val p50 = percentile(sorted, 50)
+    val p95 = percentile(sorted, 95)
+    val callTotalNanos = sorted.foldLeft(0L)(_ + _)
+    SampleStats(
+      count = iterations,
+      totalWallNanos = runTotalNanos,
+      totalCallNanos = callTotalNanos,
+      minNanos = min,
+      maxNanos = max,
+      p50Nanos = p50,
+      p95Nanos = p95
+    )
+  }
+
+  private def percentile(sorted: Array[Long], p: Int): Long = {
+    val idx = math.min(sorted.length - 1, math.max(0, ((sorted.length - 1L) * p / 100L).toInt))
+    sorted(idx)
+  }
+
+  private def assertSat(result: Z3Result, context: String): Unit =
+    result match {
+      case Z3Result.Success(stdout, stderr, _) =>
+        if (!stdout.linesIterator.exists(_.trim == "sat")) {
+          throw new RuntimeException(
+            s"Expected sat status in $context\nstdout:\n$stdout\nstderr:\n$stderr"
+          )
+        }
+      case Z3Result.Failure(msg, _, stdout, stderr, _) =>
+        throw new RuntimeException(
+          s"Solver failed in $context: $msg\nstdout:\n$stdout\nstderr:\n$stderr"
+        )
+    }
+
+  private def toMillis(nanos: Long): Double = nanos.toDouble / 1e6
+
+  private def parseConfig(args: List[String]): Config = {
+    @annotation.tailrec
+    def loop(rest: List[String], acc: Config): Config =
+      rest match {
+        case Nil => acc
+        case "--warmup" :: value :: tail =>
+          loop(tail, acc.copy(warmupIterations = parsePositiveInt("--warmup", value)))
+        case "--iterations" :: value :: tail =>
+          loop(tail, acc.copy(measuredIterations = parsePositiveInt("--iterations", value)))
+        case "--threads" :: value :: tail =>
+          loop(tail, acc.copy(threads = parsePositiveInt("--threads", value)))
+        case "--mode" :: value :: tail =>
+          loop(tail, acc.copy(mode = SolverMode.parse(value)))
+        case "--help" :: _ =>
+          printUsageAndExit()
+          acc
+        case flag :: _ =>
+          throw new IllegalArgumentException(s"Unknown argument: $flag")
+      }
+
+    loop(args, Config())
+  }
+
+  private def parsePositiveInt(flag: String, value: String): Int = {
+    val parsed =
+      try value.toInt
+      catch {
+        case _: NumberFormatException =>
+          throw new IllegalArgumentException(s"$flag expects an integer, got: $value")
+      }
+    if (parsed <= 0) {
+      throw new IllegalArgumentException(s"$flag must be > 0, got: $parsed")
+    }
+    parsed
+  }
+
+  private def validateConfig(cfg: Config): Unit = {
+    if (cfg.threads <= 0) {
+      throw new IllegalArgumentException("threads must be > 0")
+    }
+    if (cfg.measuredIterations < cfg.threads) {
+      throw new IllegalArgumentException(
+        s"iterations (${cfg.measuredIterations}) must be >= threads (${cfg.threads})"
+      )
+    }
+  }
+
+  private def printUsageAndExit(): Unit = {
+    val text =
+      """Usage:
+        |  runMain dev.bosatsu.scalawasiz3.JvmSolverBenchmarkMain [--warmup N] [--iterations N] [--threads N] [--mode shared|isolated]
+        |
+        |Defaults:
+        |  --warmup 20
+        |  --iterations 200
+        |  --threads 1
+        |  --mode shared
+        |""".stripMargin
+    Console.out.println(text)
+    sys.exit(0)
+  }
+
+  private def modeName(mode: SolverMode): String =
+    mode match {
+      case SolverMode.Shared => "shared"
+      case SolverMode.Isolated => "isolated"
+    }
+}

--- a/core/jvm/src/main/scala/dev/bosatsu/scalawasiz3/JvmWasiZ3Solver.scala
+++ b/core/jvm/src/main/scala/dev/bosatsu/scalawasiz3/JvmWasiZ3Solver.scala
@@ -1,21 +1,43 @@
 package dev.bosatsu.scalawasiz3
 
+import com.dylibso.chicory.compiler.InterpreterFallback
+import com.dylibso.chicory.compiler.MachineFactoryCompiler
+import com.dylibso.chicory.experimental.dircache.DirectoryCache
 import com.dylibso.chicory.runtime.ByteArrayMemory
 import com.dylibso.chicory.runtime.ImportFunction
+import com.dylibso.chicory.runtime.ImportValues
 import com.dylibso.chicory.runtime.Instance
-import com.dylibso.chicory.runtime.Store
+import com.dylibso.chicory.runtime.Machine
 import com.dylibso.chicory.runtime.alloc.ExactMemAllocStrategy
 import com.dylibso.chicory.wasi.WasiExitException
 import com.dylibso.chicory.wasi.WasiOptions
 import com.dylibso.chicory.wasi.WasiPreview1
 import com.dylibso.chicory.wasm.Parser
 import com.dylibso.chicory.wasm.WasmModule
+import com.dylibso.chicory.wasm.types.MemoryLimits
 
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+import java.util.function.Function
 
-private[scalawasiz3] object JvmWasiZ3Solver extends Z3Solver {
+private[scalawasiz3] object JvmWasiZ3Solver {
+  private val z3Arguments = java.util.List.of("z3", "-smt2", "-in")
+  private val runtimeCompilerCacheDirProperty = "scalawasiz3.chicory.runtimeCompilerCacheDir"
+  private val exactAllocator = new ExactMemAllocStrategy()
+  private val memoryFactory: Function[MemoryLimits, com.dylibso.chicory.runtime.Memory] =
+    (limits: MemoryLimits) => new ByteArrayMemory(limits, exactAllocator)
+
+  lazy val default: Z3Solver = create()
+
+  def create(): Z3Solver = new JvmWasiZ3Solver()
+
+  private lazy val runtimeEither: Either[String, RuntimeState] =
+    wasmModuleEither.map { module =>
+      RuntimeState(module = module, machineFactory = compileMachineFactory(module))
+    }
+
   private lazy val wasmBytesEither: Either[String, Array[Byte]] = {
     val stream = Option(getClass.getResourceAsStream(Z3WasmResource.ClasspathResourcePath))
     stream match {
@@ -41,76 +63,111 @@ private[scalawasiz3] object JvmWasiZ3Solver extends Z3Solver {
       }
     }
 
-  def runSmt2(input: String): Z3Result = {
-    wasmModuleEither match {
-      case Left(err) =>
+  private def compileMachineFactory(module: WasmModule): Option[Function[Instance, Machine]] = {
+    try {
+      val builder = MachineFactoryCompiler
+        .builder(module)
+        .withInterpreterFallback(InterpreterFallback.SILENT)
+
+      runtimeCompilerCacheDir.foreach { cacheDir =>
+        try {
+          builder.withCache(new DirectoryCache(Paths.get(cacheDir)))
+        } catch {
+          case _: Throwable =>
+            ()
+        }
+      }
+
+      Some(builder.compile())
+    } catch {
+      case _: Throwable =>
+        None
+    }
+  }
+
+  private lazy val runtimeCompilerCacheDir: Option[String] =
+    Option(System.getProperty(runtimeCompilerCacheDirProperty)).map(_.trim).filter(_.nonEmpty)
+
+  private final case class RuntimeState(
+      module: WasmModule,
+      machineFactory: Option[Function[Instance, Machine]]
+  )
+
+  private final class JvmWasiZ3Solver extends Z3Solver {
+    override def runSmt2(input: String): Z3Result =
+      runtimeEither match {
+        case Left(err) =>
+          Z3Result.Failure(
+            message = err,
+            exitCode = None,
+            stdout = "",
+            stderr = ""
+          )
+
+        case Right(runtime) =>
+          runWithRuntime(runtime, input)
+      }
+  }
+
+  private def runWithRuntime(runtime: RuntimeState, input: String): Z3Result = {
+    val stdin = new ByteArrayInputStream(normalizeInput(input).getBytes(StandardCharsets.UTF_8))
+    val stdout = new ByteArrayOutputStream()
+    val stderr = new ByteArrayOutputStream()
+
+    val options = WasiOptions
+      .builder()
+      .withArguments(z3Arguments)
+      .withStdin(stdin)
+      .withStdout(stdout)
+      .withStderr(stderr)
+      .withThrowOnExit0(false)
+      .build()
+
+    val wasi = WasiPreview1.builder().withOptions(options).build()
+
+    try {
+      val hostFunctions = wasi.toHostFunctions().map(_.asInstanceOf[ImportFunction])
+      val importValues = ImportValues.builder().addFunction(hostFunctions*).build()
+
+      val builder = Instance
+        .builder(runtime.module)
+        .withImportValues(importValues)
+        .withMemoryFactory(memoryFactory)
+
+      runtime.machineFactory.foreach(factory => builder.withMachineFactory(factory))
+      builder.build()
+
+      Z3Result.Success(stdout = asUtf8(stdout), stderr = asUtf8(stderr))
+    } catch {
+      case e: WasiExitException if e.exitCode() == 0 =>
+        Z3Result.Success(stdout = asUtf8(stdout), stderr = asUtf8(stderr))
+
+      case e: WasiExitException =>
         Z3Result.Failure(
-          message = err,
-          exitCode = None,
-          stdout = "",
-          stderr = ""
+          message = s"z3 exited with code ${e.exitCode()}",
+          exitCode = Some(e.exitCode()),
+          stdout = asUtf8(stdout),
+          stderr = asUtf8(stderr),
+          cause = Some(e)
         )
 
-      case Right(module) =>
-        val stdin = new ByteArrayInputStream(normalizeInput(input).getBytes(StandardCharsets.UTF_8))
-        val stdout = new ByteArrayOutputStream()
-        val stderr = new ByteArrayOutputStream()
-
-        val options = WasiOptions
-          .builder()
-          .withArguments(java.util.List.of("z3", "-smt2", "-in"))
-          .withStdin(stdin)
-          .withStdout(stdout)
-          .withStderr(stderr)
-          .build()
-
-        val wasi = WasiPreview1.builder().withOptions(options).build()
-        val hostFunctions = wasi.toHostFunctions().map(_.asInstanceOf[ImportFunction])
-        val store = new Store().addFunction(hostFunctions*)
-        val exactAllocator = new ExactMemAllocStrategy()
-
-        try {
-          store.instantiate(
-            "z3",
-            imports =>
-              Instance
-                .builder(module)
-                .withImportValues(imports)
-                .withMemoryFactory(limits => new ByteArrayMemory(limits, exactAllocator))
-                .build()
+      case t: Throwable =>
+        val out = asUtf8(stdout)
+        val err = asUtf8(stderr)
+        if (containsStatusLine(out)) {
+          // Some WASI builds may trap during teardown after writing a valid result.
+          Z3Result.Success(stdout = out, stderr = err)
+        } else {
+          Z3Result.Failure(
+            message = s"Failed executing embedded z3.wasm: ${t.getMessage}",
+            exitCode = None,
+            stdout = out,
+            stderr = err,
+            cause = Some(t)
           )
-          Z3Result.Success(stdout = asUtf8(stdout), stderr = asUtf8(stderr))
-        } catch {
-          case e: WasiExitException if e.exitCode() == 0 =>
-            Z3Result.Success(stdout = asUtf8(stdout), stderr = asUtf8(stderr))
-
-          case e: WasiExitException =>
-            Z3Result.Failure(
-              message = s"z3 exited with code ${e.exitCode()}",
-              exitCode = Some(e.exitCode()),
-              stdout = asUtf8(stdout),
-              stderr = asUtf8(stderr),
-              cause = Some(e)
-            )
-
-          case t: Throwable =>
-            val out = asUtf8(stdout)
-            val err = asUtf8(stderr)
-            if (containsStatusLine(out)) {
-              // Some WASI builds may trap during teardown after writing a valid result.
-              Z3Result.Success(stdout = out, stderr = err)
-            } else {
-              Z3Result.Failure(
-                message = s"Failed executing embedded z3.wasm: ${t.getMessage}",
-                exitCode = None,
-                stdout = out,
-                stderr = err,
-                cause = Some(t)
-              )
-            }
-        } finally {
-          wasi.close()
         }
+    } finally {
+      wasi.close()
     }
   }
 

--- a/core/jvm/src/main/scala/dev/bosatsu/scalawasiz3/Z3Platform.scala
+++ b/core/jvm/src/main/scala/dev/bosatsu/scalawasiz3/Z3Platform.scala
@@ -1,5 +1,7 @@
 package dev.bosatsu.scalawasiz3
 
 object Z3Platform {
-  lazy val default: Z3Solver = JvmWasiZ3Solver
+  lazy val default: Z3Solver = JvmWasiZ3Solver.default
+
+  def create(): Z3Solver = JvmWasiZ3Solver.create()
 }

--- a/core/jvm/src/test/scala/dev/bosatsu/scalawasiz3/JvmSolverConcurrencySuite.scala
+++ b/core/jvm/src/test/scala/dev/bosatsu/scalawasiz3/JvmSolverConcurrencySuite.scala
@@ -1,0 +1,55 @@
+package dev.bosatsu.scalawasiz3
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+
+class JvmSolverConcurrencySuite extends munit.FunSuite {
+  test("multiple solver instances can execute concurrently") {
+    val threadCount = 4
+    val runsPerThread = 4
+    val start = new CountDownLatch(1)
+    val done = new CountDownLatch(threadCount)
+    val failures = new ConcurrentLinkedQueue[String]()
+
+    var t = 0
+    while (t < threadCount) {
+      val threadIndex = t
+      val thread = new Thread(
+        new Runnable {
+          override def run(): Unit = {
+            val solver = Z3Solver.create()
+            try {
+              start.await()
+              var i = 0
+              while (i < runsPerThread) {
+                solver.runSmt2("(check-sat)") match {
+                  case Z3Result.Success(stdout, _, _) =>
+                    val hasSat = stdout.linesIterator.exists(_.trim == "sat")
+                    if (!hasSat) {
+                      failures.add(s"missing sat status on thread=$threadIndex run=$i")
+                    }
+                  case Z3Result.Failure(message, _, _, _, _) =>
+                    failures.add(s"solver failure on thread=$threadIndex run=$i: $message")
+                }
+                i += 1
+              }
+            } catch {
+              case e: Throwable =>
+                failures.add(s"thread failure on thread=$threadIndex: ${e.getMessage}")
+            } finally {
+              done.countDown()
+            }
+          }
+        },
+        s"z3-concurrency-$threadIndex"
+      )
+      thread.start()
+      t += 1
+    }
+
+    start.countDown()
+    done.await()
+
+    assertEquals(failures.size(), 0, failures.toString)
+  }
+}

--- a/core/shared/src/main/scala/dev/bosatsu/scalawasiz3/Z3Solver.scala
+++ b/core/shared/src/main/scala/dev/bosatsu/scalawasiz3/Z3Solver.scala
@@ -6,4 +6,11 @@ trait Z3Solver {
 
 object Z3Solver {
   lazy val default: Z3Solver = Z3Platform.default
+
+  /**
+   * Create a solver handle suitable for reuse in one thread or worker.
+   *
+   * `default` remains available for callers that want a singleton handle.
+   */
+  def create(): Z3Solver = Z3Platform.create()
 }

--- a/core/shared/src/test/scala/dev/bosatsu/scalawasiz3/Z3SolverSmokeSuite.scala
+++ b/core/shared/src/test/scala/dev/bosatsu/scalawasiz3/Z3SolverSmokeSuite.scala
@@ -16,4 +16,13 @@ class Z3SolverSmokeSuite extends munit.FunSuite {
     assert(one != null)
     assert(two != null)
   }
+
+  test("create returns a reusable solver instance") {
+    val solver = Z3Solver.create()
+    val one = solver.runSmt2("(check-sat)")
+    val two = solver.runSmt2("(check-sat)")
+
+    assert(one != null)
+    assert(two != null)
+  }
 }

--- a/versions.properties
+++ b/versions.properties
@@ -1,4 +1,4 @@
 z3.tag=z3-4.16.0
 wasi.sdk.version=30.0
-chicory.version=1.4.0
+chicory.version=1.7.2
 scala.version=3.8.1


### PR DESCRIPTION
## Summary
- upgrade JVM Chicory dependencies from `1.4.0` to `1.7.2` and enable the runtime compiler path for the embedded Z3 WASM module
- keep the string-in/result-out API intact while adding `Z3Solver.create()` for reusable per-thread solver handles
- refactor JVM solver internals to reuse parsed module + compiled machine factory across calls, and use `WasiOptions.withThrowOnExit0(false)` to avoid exception-driven success exits
- add an optional Chicory runtime compiler disk cache knob via `-Dscalawasiz3.chicory.runtimeCompilerCacheDir=...`
- add a JVM benchmark harness and a concurrency test for parallel solver instances

## Cache Directory Behavior
`scalawasiz3.chicory.runtimeCompilerCacheDir` controls whether Chicory runtime-compiled bytecode is persisted to disk.

- If **unset**: compiled machine bytecode is kept in-memory only (still compiled once and reused for the process).
- If **set**: Chicory also stores/loads runtime-compiled bytecode from disk, which helps avoid recompilation cost across process restarts.

For this implementation, steady-state benchmark throughput is expected to be similar with or without cache dir, because the solver already reuses the compiled machine factory in-process.

## Benchmark
Command shape used:

```bash
sbt "project coreJVM" "runMain dev.bosatsu.scalawasiz3.JvmSolverBenchmarkMain --warmup 20 --iterations 200 --threads N --mode shared"
```

### Before (old implementation)
- 1 thread: `2.51 calls/s` (200 calls in `79.794s`)
- 4 threads: `4.50 calls/s` (200 calls in `44.478s`)

### After (no cache dir)
- 1 thread: `50.68 calls/s` (200 calls in `3.946s`)
- 4 threads: `125.56 calls/s` (200 calls in `1.593s`)

### After (cache dir set)
(cache path: `/tmp/scalawasiz3-chicory-cache.AmgPYa`)
- 1 thread (first cached run): `47.43 calls/s` (200 calls in `4.217s`)
- 1 thread (warm cached run): `50.29 calls/s` (200 calls in `3.977s`)
- 4 threads (first cached run): `135.35 calls/s` (200 calls in `1.478s`)
- 4 threads (warm cached run): `115.56 calls/s` (200 calls in `1.731s`)

Interpretation: cache dir does not materially change steady-state throughput in this benchmark; differences are run-to-run variance. Cache dir is primarily for compile-cost reuse across fresh processes.

## Validation
- `sbt test`
- `sbt "project coreJVM" test`
