### PR TITLE
[codex] Fix qflia fallback trap in WASI build

### DIFF
--- a/core/shared/src/test/scala/dev/bosatsu/scalawasiz3/Z3Issue14Suite.scala
+++ b/core/shared/src/test/scala/dev/bosatsu/scalawasiz3/Z3Issue14Suite.scala
@@ -140,6 +140,46 @@ class Z3Issue14Suite extends munit.FunSuite {
     )
   }
 
+  test("qflia tactic fallback proves the bosatsu contradiction unsat") {
+    assertStatus(
+      """(set-logic QF_LIA)
+        |(declare-const v Int)
+        |(declare-const z Int)
+        |(assert (< v (+ z v)))
+        |(assert (not (<= 1 z)))
+        |(check-sat-using qflia)
+        |""".stripMargin,
+      "unsat"
+    )
+  }
+
+  test("qflia tactic fallback does not turn the sat twin into unsat") {
+    assertStatus(
+      """(set-logic QF_LIA)
+        |(declare-const v Int)
+        |(declare-const z Int)
+        |(assert (< v (+ z v)))
+        |(assert (<= 1 z))
+        |(check-sat-using qflia)
+        |(get-model)
+        |""".stripMargin,
+      "sat",
+      expectModel = true,
+      expectedSymbolsInModel = List("v", "z")
+    )
+  }
+
+  test("non-applicable pb2bv tactic stays unknown instead of trapping") {
+    assertStatus(
+      """(set-logic QF_LIA)
+        |(declare-const x Int)
+        |(assert (> x 0))
+        |(check-sat-using (then pb2bv fail-if-undecided))
+        |""".stripMargin,
+      "unknown"
+    )
+  }
+
   test("design doc obligation query shape works with concrete PC and GOAL") {
     assertStatus(
       """(set-logic QF_LIA)

--- a/core/shared/src/test/scala/dev/bosatsu/scalawasiz3/Z3Issue14Suite.scala
+++ b/core/shared/src/test/scala/dev/bosatsu/scalawasiz3/Z3Issue14Suite.scala
@@ -127,6 +127,19 @@ class Z3Issue14Suite extends munit.FunSuite {
     )
   }
 
+  test("bosatsu pathImplies strict interval contradiction is unsat") {
+    assertStatus(
+      """(set-logic QF_LIA)
+        |(declare-const v Int)
+        |(declare-const z Int)
+        |(assert (< v (+ z v)))
+        |(assert (not (<= 1 z)))
+        |(check-sat)
+        |""".stripMargin,
+      "unsat"
+    )
+  }
+
   test("design doc obligation query shape works with concrete PC and GOAL") {
     assertStatus(
       """(set-logic QF_LIA)

--- a/scripts/z3-wasi-patches/0005-wasi-noexcept-qflia-fallback.patch
+++ b/scripts/z3-wasi-patches/0005-wasi-noexcept-qflia-fallback.patch
@@ -1,0 +1,62 @@
+--- a/src/tactic/smtlogics/qflia_tactic.cpp
++++ b/src/tactic/smtlogics/qflia_tactic.cpp
+@@ -36,6 +36,23 @@
+ #include "ast/simplifiers/bound_manager.h"
+ #include "tactic/arith/probe_arith.h"
+ 
++class fail_if_undecided_noexcept_tactic : public skip_tactic {
++public:
++    char const* name() const override { return "fail_if_undecided_noexcept"; }
++
++    void operator()(goal_ref const & in, goal_ref_buffer& result) override {
++        if (!in->is_decided()) {
++            result.reset();
++            return;
++        }
++        skip_tactic::operator()(in, result);
++    }
++};
++
++static tactic * mk_fail_if_undecided_noexcept_tactic() {
++    return alloc(fail_if_undecided_noexcept_tactic);
++}
++
+ struct quasi_pb_probe : public probe {
+     result operator()(goal const & g) override {
+         bool found_non_01 = false;
+@@ -113,7 +130,7 @@
+                  or_else(and_then(fail_if(mk_ge(mk_num_exprs_probe(), mk_const_probe(SMALL_SIZE))),
+                                   fail_if_not(mk_is_ilp_probe()),
+                                   // try_for(mk_mip_tactic(m), 8000),
+-                                  mk_fail_if_undecided_tactic()),
++                                  mk_fail_if_undecided_noexcept_tactic()),
+                          and_then(using_params(mk_pb2bv_tactic(m), pb2bv_p),
+                                   fail_if_not(mk_is_qfbv_probe()),
+                                   using_params(mk_bv2sat_tactic(m), bv2sat_p)))));
+@@ -165,7 +182,7 @@
+                               try_for(mk_lia2sat_tactic(m), 10000))
+                      // , mk_mip_tactic(m)
+                          ),
+-                 mk_fail_if_undecided_tactic()));
++                 mk_fail_if_undecided_noexcept_tactic()));
+ }
+ 
+ static tactic * mk_bounded_tactic(ast_manager & m) {
+@@ -176,7 +193,7 @@
+                          try_for(mk_no_cut_no_relevancy_smt_tactic(m, 200), 5000),
+                          try_for(mk_no_cut_smt_tactic(m, 300), 15000)
+                          ),
+-                 mk_fail_if_undecided_tactic()));
++                 mk_fail_if_undecided_noexcept_tactic()));
+ }
+ 
+ tactic * mk_preamble_tactic(ast_manager& m) {
+@@ -232,7 +249,7 @@
+                 mk_pb_tactic(m),
+                 and_then(fail_if_not(mk_is_quasi_pb_probe()),
+                     using_params(mk_lia2sat_tactic(m), quasi_pb_p),
+-                    mk_fail_if_undecided_tactic()),
++                    mk_fail_if_undecided_noexcept_tactic()),
+                 mk_bounded_tactic(m),
+                 mk_smt_tactic(m))),
+         main_p);


### PR DESCRIPTION
## Summary

This change fixes a WASI-only trap in the `qflia` tactic fallback path and adds a regression test for the Bosatsu-discovered query in the shared test suite so it runs on all backends.

## Root cause

`qflia_tactic.cpp` uses `mk_fail_if_undecided_tactic()` as part of tactic fallback control flow. In native Z3 that throws a `tactic_exception` which is caught by `or_else`. In the no-exception WASM build, the same path traps instead of declining and falling through to the next tactic.

## What changed

- add a shared regression test for the Bosatsu `pathImplies` contradiction case
- add a WASI patch that replaces the throw-on-undecided behavior in `qflia_tactic.cpp` with a no-throw decline tactic
- rebuild the embedded `z3.wasm` via the existing patch flow

## Impact

The embedded WASM solver now returns `unsat` for this query instead of trapping, and the regression is covered across JVM, JS, and Native test runs.

## Validation

- `sbt 'coreJVM/testOnly dev.bosatsu.scalawasiz3.Z3Issue14Suite' 'coreJS/testOnly dev.bosatsu.scalawasiz3.Z3Issue14Suite' 'coreNative/testOnly dev.bosatsu.scalawasiz3.Z3Issue14Suite'`
- `SCALAWASIZ3_Z3_NATIVE_LIB_DIR=/opt/homebrew/lib sbt test`
